### PR TITLE
Refactor to encapsulate the main loop

### DIFF
--- a/cmd/ui/main.go
+++ b/cmd/ui/main.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/BurntSushi/toml"
-	"github.com/rivo/tview"
 	"github.com/timaraxian/alias-gen/pkg/database"
 	"github.com/timaraxian/alias-gen/pkg/tui"
 )
@@ -32,133 +31,7 @@ func main() {
 		panic(err)
 	}
 
-
-	var list *tview.List
-	var form *tview.Form
-	var table *tview.Table
-	var modal *tview.Modal
-
-	for {
-		if app.NextState == "stop" {
-			break
-		}
-		if app.PrevState != app.NextState {
-			app.Update = false
-			switch app.NextState {
-			case "menu":
-				list = app.ShowMenu()
-
-				//Words
-			case "addWord":
-				form = app.ShowNewWord()
-			case "submitWord":
-				err = app.SubmitNewWord()
-				if err != nil {
-					panic(err)
-				}
-			case "listWords":
-				table = app.ListWords()
-			case "viewWordListArgs":
-				form = app.ShowWordListArgs()
-			case "viewWord":
-				list = app.ViewWord()
-			case "editWordWord":
-				form = app.ShowEditWordWord()
-			case "submitWordWord":
-				err = app.SubmitWordWord()
-				if err != nil {
-					panic(err)
-				}
-			case "editWordLanguage":
-				form = app.ShowEditWordLanguage()
-			case "submitWordLanguage":
-				err = app.SubmitWordLanguage()
-				if err != nil {
-					panic(err)
-				}
-			case "editWordPart":
-				form = app.ShowEditWordPart()
-			case "submitWordPart":
-				err = app.SubmitWordPart()
-				if err != nil {
-					panic(err)
-				}
-			case "editWordArchive":
-				form = app.ShowEditWordArchive()
-			case "submitWordArchive":
-				err = app.SubmitWordArchive()
-				if err != nil {
-					panic(err)
-				}
-
-				//Patterns
-			case "addPattern":
-				form = app.ShowNewPattern()
-			case "submitPattern":
-				err = app.SubmitNewPattern()
-				if err != nil {
-					panic(err)
-				}
-			case "listPatterns":
-				table = app.ListPatterns()
-			case "viewPatternListArgs":
-				form = app.ShowPatternListArgs()
-			case "viewPattern":
-				list = app.ViewPattern()
-			case "editPatternPattern":
-				form = app.ShowEditPatternPattern()
-			case "submitPatternPattern":
-				err = app.SubmitPatternPattern()
-				if err != nil {
-					panic(err)
-				}
-			case "editPatternLanguage":
-				form = app.ShowEditPatternLanguage()
-			case "submitPatternLanguage":
-				err = app.SubmitPatternLanguage()
-				if err != nil {
-					panic(err)
-				}
-			case "editPatternArchive":
-				form = app.ShowEditPatternArchive()
-			case "submitPatternArchive":
-				err = app.SubmitPatternArchive()
-				if err != nil {
-					panic(err)
-				}
-
-				//random
-			case "selectLanguage":
-				form = app.SelectLanguage()
-			case "showRandomAlias":
-				modal = app.ShowRandomAlias()
-			}
-		}
-
-		if app.Update {
-			switch app.PrevState {
-			case "menu", "viewWord", "viewPattern":
-				err := app.Ui.SetRoot(list, true).SetFocus(list).Run()
-				if err != nil {
-					panic(err)
-				}
-			case "addWord", "editWordWord", "editWordLanguage", "editWordPart", "editWordArchive", "viewWordListArgs", "addPattern", "editPatternPattern", "editPatternLanguage", "editPatternArchive", "viewPatternListArgs", "selectLanguage":
-				err := app.Ui.SetRoot(form, true).SetFocus(form).Run()
-				if err != nil {
-					panic(err)
-				}
-			case "listWords", "listPatterns":
-				err := app.Ui.SetRoot(table, true).SetFocus(table).Run()
-				if err != nil {
-					panic(err)
-				}
-			case "showRandomAlias", "err":
-				err := app.Ui.SetRoot(modal, true).SetFocus(modal).Run()
-				if err != nil {
-					panic(err)
-				}
-			}
-
-		}
+	if err := app.Loop(); err != nil {
+		panic(err)
 	}
 }

--- a/pkg/tui/loop.go
+++ b/pkg/tui/loop.go
@@ -1,0 +1,135 @@
+package tui
+
+import "github.com/rivo/tview"
+
+func (app *App) Loop() (err error) {
+
+	var list *tview.List
+	var form *tview.Form
+	var table *tview.Table
+	var modal *tview.Modal
+
+	for {
+		if app.NextState == "stop" {
+			break
+		}
+		if app.PrevState != app.NextState {
+			app.Update = false
+			switch app.NextState {
+			case "menu":
+				list = app.ShowMenu()
+
+				//Words
+			case "addWord":
+				form = app.ShowNewWord()
+			case "submitWord":
+				err = app.SubmitNewWord()
+				if err != nil {
+					return err
+				}
+			case "listWords":
+				table = app.ListWords()
+			case "viewWordListArgs":
+				form = app.ShowWordListArgs()
+			case "viewWord":
+				list = app.ViewWord()
+			case "editWordWord":
+				form = app.ShowEditWordWord()
+			case "submitWordWord":
+				err = app.SubmitWordWord()
+				if err != nil {
+					return err
+				}
+			case "editWordLanguage":
+				form = app.ShowEditWordLanguage()
+			case "submitWordLanguage":
+				err = app.SubmitWordLanguage()
+				if err != nil {
+					return err
+				}
+			case "editWordPart":
+				form = app.ShowEditWordPart()
+			case "submitWordPart":
+				err = app.SubmitWordPart()
+				if err != nil {
+					return err
+				}
+			case "editWordArchive":
+				form = app.ShowEditWordArchive()
+			case "submitWordArchive":
+				err = app.SubmitWordArchive()
+				if err != nil {
+					return err
+				}
+
+				//Patterns
+			case "addPattern":
+				form = app.ShowNewPattern()
+			case "submitPattern":
+				err = app.SubmitNewPattern()
+				if err != nil {
+					return err
+				}
+			case "listPatterns":
+				table = app.ListPatterns()
+			case "viewPatternListArgs":
+				form = app.ShowPatternListArgs()
+			case "viewPattern":
+				list = app.ViewPattern()
+			case "editPatternPattern":
+				form = app.ShowEditPatternPattern()
+			case "submitPatternPattern":
+				err = app.SubmitPatternPattern()
+				if err != nil {
+					return err
+				}
+			case "editPatternLanguage":
+				form = app.ShowEditPatternLanguage()
+			case "submitPatternLanguage":
+				err = app.SubmitPatternLanguage()
+				if err != nil {
+					return err
+				}
+			case "editPatternArchive":
+				form = app.ShowEditPatternArchive()
+			case "submitPatternArchive":
+				err = app.SubmitPatternArchive()
+				if err != nil {
+					return err
+				}
+
+				//random
+			case "selectLanguage":
+				form = app.SelectLanguage()
+			case "showRandomAlias":
+				modal = app.ShowRandomAlias()
+			}
+		}
+
+		if app.Update {
+			switch app.PrevState {
+			case "menu", "viewWord", "viewPattern":
+				err := app.Ui.SetRoot(list, true).SetFocus(list).Run()
+				if err != nil {
+					return err
+				}
+			case "addWord", "editWordWord", "editWordLanguage", "editWordPart", "editWordArchive", "viewWordListArgs", "addPattern", "editPatternPattern", "editPatternLanguage", "editPatternArchive", "viewPatternListArgs", "selectLanguage":
+				err := app.Ui.SetRoot(form, true).SetFocus(form).Run()
+				if err != nil {
+					return err
+				}
+			case "listWords", "listPatterns":
+				err := app.Ui.SetRoot(table, true).SetFocus(table).Run()
+				if err != nil {
+					return err
+				}
+			case "showRandomAlias", "err":
+				err := app.Ui.SetRoot(modal, true).SetFocus(modal).Run()
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
I moved the main loop into the app package and left the panic at the cmd layer, so the loop returns an error. Should be easier to test and refactor, and keeps cmd agnostic to how the app works.